### PR TITLE
[31] Fix player playback when changing sections

### DIFF
--- a/app/javascript/controllers/section_controller.js
+++ b/app/javascript/controllers/section_controller.js
@@ -4,6 +4,9 @@ export default class extends Controller {
   static outlets = [ "player" ]
 
   connect() {
+    console.log(this.element.dataset)
+    console.log(`Section load start: ${this.element.dataset.start}`)
+    console.log(`Section load end: ${this.element.dataset.end}`)
     const start = parseFloat(this.element.dataset.start)
     const end = parseFloat(this.element.dataset.end)
 


### PR DESCRIPTION
Closes #31 

Fixes the player restarting playback from the beginning of the video instead of the starting point of the selected section. Also refactors some stateful and event-based parts.