### PR TITLE
[#54] Enable safari fullscreen mode

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
   <head>
     <title>Along</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <meta name="apple-mobile-web-app-cabable" content="yes"/>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>

--- a/test/system/lessons_test.rb
+++ b/test/system/lessons_test.rb
@@ -41,6 +41,11 @@ class LessonsTest < ApplicationSystemTestCase
     assert_text "New Light"
   end
 
+  test "should have app-capable meta tag" do
+    visit lesson_url(@lesson)
+    find 'meta[name="apple-mobile-web-app-capable"][content="yes"]', visible: :all
+  end
+
   # FIXME: Turbo stream flash notices
   # test "should destroy Lesson" do
   #   visit lesson_url(@lesson)


### PR DESCRIPTION
Closes #54 
- Remove support from main layout. This will only be supported by the Lesson#show view
- Add test to check that the page has the tag