### PR TITLE
[#70] Fix picking point infinite loop

### DIFF
--- a/app/javascript/controllers/player/loop_manager.js
+++ b/app/javascript/controllers/player/loop_manager.js
@@ -36,6 +36,7 @@ export default class LoopManager {
    * loop
    */
   async loop(from, to, max = null) {
+    debug(`LoopManager: Starting loop from ${from} to ${to}`)
     // We need to stop any previous loop before we start a new one
     await this.clear()
 
@@ -45,8 +46,8 @@ export default class LoopManager {
     const signal = this.#abortController.signal
 
     return new Promise ((resolve, reject) => {
+        debug("LoopManager: Interval promise", { max, intervalId: this.#intervalId, times: this.#times, from, to, currentTime: this.#player.currentTime })
       this.#intervalId = setInterval(() => {
-
         if (this.#player.currentTime >= to) {
           this.#player.play(from)
 
@@ -68,7 +69,7 @@ export default class LoopManager {
           clearInterval(this.#intervalId)
           resolve()
         }
-      }, 500)
+      }, 200)
     })
   }
 
@@ -78,19 +79,36 @@ export default class LoopManager {
    * If there's a loop active we use the abort controller to stop it.
    */
   async clear() {
+    debug("LoopManager: Clearing loop: ", { invervalId: this.#intervalId, times: this.#times })
+    this.#times = 0
     if(this.#intervalId !== null && this.#intervalId !== undefined) {
-      debug("Interval id of this operation", this.#intervalId)
-      this.#times = 0
       if(this.#abortController !== null && this.#abortController !== undefined && !this.#abortController.signal.aborted) {
-        debug("aborting")
+        debug("LoopManager: Aborting")
         this.#abortController.abort("LoopManager: Cancelled manually")
       } else {
-        debug("Already aborted")
+        debug("LoopManager: Already aborted")
       }
       this.#intervalId = null
       this.#aborted = false
     } else {
-      debug("No interval")
+      debug("LoopManager: No interval")
     }
+  }
+
+  static settingRange(start, end, setting) {
+    let finalEnd, finalStart;
+
+    switch(setting) {
+      case start:
+        finalStart = start
+        finalEnd = start + 3
+        break
+      case end:
+        finalEnd = end
+        finalStart = Math.max(end - 3, 0)
+        break
+    }
+
+    return [finalStart, finalEnd]
   }
 }

--- a/app/javascript/controllers/player/state.js
+++ b/app/javascript/controllers/player/state.js
@@ -77,9 +77,9 @@ export class EditingState extends PlayerState {
 
 export class PickingPointState extends PlayerState {
   async loop(from, to) {
-    debug("Looping 3 times", { state: this.constructor.name, from, to })
+    debug("PickingPointState: Looping 3 times", { state: this.constructor.name, from, to })
     await this.context.loopManager.loop(from, to, 1)
-    debug("Done point looping. Doing editing loop:", this.context.editState)
+    debug("PickingPointState: Done point looping. Doing editing loop:", this.context.editState)
     this.context.state = this.context.editingState
     this.context.editState = { ...this.context.editState, setting: null }
     this.context.loop(this.context.editState.start, this.context.editState.end)

--- a/app/javascript/controllers/range_controller.js
+++ b/app/javascript/controllers/range_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
   static outlets = [ "player" ]
 
   connect() {
-    debug("connected range controller")
+    debug("RangeController: connected range controller")
     this.dispatch("connect", { detail: {
       start: parseFloat(this.minTarget.value),
       end: parseFloat(this.maxTarget.value)
@@ -48,9 +48,10 @@ export default class extends Controller {
       setting = parseFloat(this.maxTarget.value)
     }
 
-    debug(`dispatch wth ${setting}`)
+    const detail = { start: parseFloat(this.minTarget.value), end: parseFloat(this.maxTarget.value), setting: setting }
+    debug(`RangeController: dispatch wth ${setting}`)
 
     // Start the player again
-    this.dispatch("update", { detail: { start: parseFloat(this.minTarget.value), end: parseFloat(this.maxTarget.value), setting: setting } })
+    this.dispatch("update", { detail })
   }
 }

--- a/test/javascript/controllers/player/loop_manager_test.js
+++ b/test/javascript/controllers/player/loop_manager_test.js
@@ -64,4 +64,26 @@ describe("LoopManager", () => {
       await expect(loop).rejects.toMatch("LoopManager: Cancelled manually")
     })
   })
+
+  describe("setting range", () => {
+    describe("when setting the start point", () => {
+      it("should be between the start point and 3 more seconds", () => {
+        expect(LoopManager.settingRange(3.0, 14.0, 3.0)).toEqual([3.0, 6.0])
+      })
+    })
+
+    describe("when setting the end point", () => {
+      describe("when 3 seconds before the end is less than the start", () => {
+        it("should be between the end point and 3 less seconds or the start", () => {
+          expect(LoopManager.settingRange(1.0, 2.0, 2.0)).toEqual([0.0, 2.0])
+        })
+      })
+
+      describe("when 3 seoncs before the end is greater than the start", () => {
+        it("should be between the 3 seconds before the end and the end", () => {
+          expect(LoopManager.settingRange(4.0, 7.0, 7.0)).toEqual([4.0,7.0])
+        })
+      })
+    })
+  })
 })

--- a/test/javascript/controllers/player_controller_test.js
+++ b/test/javascript/controllers/player_controller_test.js
@@ -16,6 +16,17 @@ jest.mock("../../../app/javascript/controllers/player/youtube_player", () => {
   })
 })
 
+jest.mock("../../../app/javascript/controllers/player/loop_manager", () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      loop: jest.fn(),
+      clear: async () => {}
+    }
+  })
+})
+
+jest.useFakeTimers();
+
 describe("PlayerController", () => {
   let application;
 
@@ -24,6 +35,7 @@ describe("PlayerController", () => {
   // That would help simplify the tests.
   beforeEach(async () => {
     YoutubePlayer.mockClear()
+    LoopManager.mockClear()
 
     document.head.innerHTML = "<script></script>"
     document.body.innerHTML = ` <div data-controller="player" data-player-video-id-value="video-id">
@@ -61,7 +73,7 @@ describe("PlayerController", () => {
 
       window.onYouTubeIframeAPIReady()
 
-      const mockLoop = jest.spyOn(LoopManager.prototype, "loop")
+      const mockLoop = jest.spyOn(playerController, "loop")
 
       playerController.playFromTo({detail: {start: 13, end: 43}})
 
@@ -87,56 +99,11 @@ describe("PlayerController", () => {
 
       window.onYouTubeIframeAPIReady()
 
-      const mockLoop = jest.spyOn(LoopManager.prototype, "loop")
+      const mockLoop = jest.spyOn(playerController, "loop")
 
       playerController.triggerEdition({detail: { start: 43, end: 65 }})
 
       expect(mockLoop).toHaveBeenCalledWith(43, 65)
-    })
-  })
-
-  describe("updatePoints", () => {
-    it("sets the state to picking point", () => {
-      const playerElement = document.querySelector('[data-controller="player"]')
-      const playerController = application.getControllerForElementAndIdentifier(playerElement, "player")
-
-      window.onYouTubeIframeAPIReady()
-
-      playerController.updatePoints({detail: { start: 34, end: 56, setting: 56 }})
-
-      expect(playerController.state).toBeInstanceOf(PickingPointState)
-    })
-
-    // TODO: The cases where either point are close to the end or the beginning
-    // don't make much sense in most cases. Tests pending.
-    describe("when setting start", () => {
-      it("calls the loop manager with start and start + 3", () => {
-        const playerElement = document.querySelector('[data-controller="player"]')
-        const playerController = application.getControllerForElementAndIdentifier(playerElement, "player")
-
-        window.onYouTubeIframeAPIReady()
-
-        const mockLoop = jest.spyOn(LoopManager.prototype, "loop")
-
-        playerController.updatePoints({detail: { start: 22, end: 77, setting: 22 }})
-
-        expect(mockLoop).toHaveBeenCalledWith(22, 25, 1)
-      })
-    })
-
-    describe("when setting end", () => {
-      it("calls the loop manager with start and start + 3", () => {
-        const playerElement = document.querySelector('[data-controller="player"]')
-        const playerController = application.getControllerForElementAndIdentifier(playerElement, "player")
-
-        window.onYouTubeIframeAPIReady()
-
-        const mockLoop = jest.spyOn(LoopManager.prototype, "loop")
-
-        playerController.updatePoints({detail: { start: 22, end: 77, setting: 22 }})
-
-        expect(mockLoop).toHaveBeenCalledWith(22, 25, 1)
-      })
     })
   })
 })


### PR DESCRIPTION
Closes #70 

- Remove race condition caused by interval in loop checking being too high
- Debounce the udpatePoints function to prevent trackpad usage from triggering too many events which causes race conditions. Also, wait for any previous loop to be fully stopped before starting another
- Extract a function to pick what range should be looped when setting a point (start/end)
- Add more messages to aid with debugging in the future
- Update test. We now mock the loop manager in certain tests to avoid issues with promises not running