### PR TITLE
[#61] Notify video is not embeddable

### DIFF
--- a/app/javascript/controllers/lesson_form_controller.js
+++ b/app/javascript/controllers/lesson_form_controller.js
@@ -1,0 +1,38 @@
+import { Controller } from "@hotwired/stimulus";
+import { show, hide, enable, disable } from "controllers/util";
+
+export default class extends Controller {
+  static targets = [ "field", "url", "errorContainer", "errorList" ]
+
+  connect() {
+    this.urlTarget.focus()
+  }
+
+  videoLoadFailed(_e) {
+    // Remove previous errors
+    this.errorListTarget.innerHTML = ''
+
+    // Create error list item
+    const li = document.createElement("li")
+    li.innerHTML = "This video is restricted from being embedded"
+
+    // Add error to error list
+    this.errorListTarget.append(li)
+
+    // Disable all relevant fields
+    this.fieldTargets.forEach(disable)
+
+    // Show the error list
+    show(this.errorContainerTarget)
+  }
+
+  videoLoaded(_e) {
+    this.errorListTarget.innerHTML = ''
+    hide(this.errorContainerTarget)
+    this.fieldTargets.forEach(enable)
+  }
+
+  load(_e) {
+    this.dispatch("videoUrlChanged", { detail: { url: this.urlTarget.value } })
+  }
+}

--- a/app/javascript/controllers/player/dummy_player.js
+++ b/app/javascript/controllers/player/dummy_player.js
@@ -1,5 +1,5 @@
 import Player from "controllers/player/player";
-import { debug } from "controllers/util";
+import { debug, randomBetween } from "controllers/util";
 
 /** Dummy Player to use in tests */
 export default class extends Player {
@@ -8,12 +8,15 @@ export default class extends Player {
   #loaded;
   #duration;
   #onPlaying;
+  #onLoadError;
 
-  constructor({ currentTime = 0, duration = 10, onPlaying = () => {} }) {
+  constructor({ currentTime = 0, duration = randomBetween(300, 600), onPlaying = () => {}, onLoadError = () => {} }) {
     super()
+
     this.#currentTime = currentTime
     this.#duration = duration
     this.#onPlaying = onPlaying
+    this.#onLoadError = onLoadError
   }
 
   get duration() {
@@ -29,9 +32,14 @@ export default class extends Player {
   }
 
   load(_url) {
-    debug("Loaded")
-    this.#onPlaying()
-    this.#loaded = true
+    const playerElement = document.querySelector("#player")
+
+    if(playerElement.dataset.error !== undefined) {
+      this.#simulateError(playerElement.dataset.error)
+    } else {
+      this.#onPlaying()
+      this.#loaded = true
+    }
   }
 
   play(from) {
@@ -51,5 +59,13 @@ export default class extends Player {
       debug("Dummy needs no preparation")
       resolve(new this(params))
     })
+  }
+
+  #simulateError(error) {
+    switch(error) {
+      case "load":
+        this.#onLoadError()
+      break
+    }
   }
 }

--- a/app/javascript/controllers/player/youtube_player.js
+++ b/app/javascript/controllers/player/youtube_player.js
@@ -40,6 +40,7 @@ export default class extends Player {
     super()
 
     const [width, height] = this.#calculateSize(params.containerOffsetHeight)
+    this.onLoadError = params.onLoadError
 
     this.#player = new YT.Player('player', {
       width: width.toString(),
@@ -66,6 +67,16 @@ export default class extends Player {
         },
         'onError': (evt) => {
           console.error(`error: ${evt.data}`)
+          switch(evt.data) {
+            case 101:
+              params.onLoadError()
+            break
+            case 150:
+              params.onLoadError()
+            break
+            default:
+              debug(`Unprocessed error: ${evt.data}`)
+          }
         }
       }
     })

--- a/app/javascript/controllers/util.js
+++ b/app/javascript/controllers/util.js
@@ -72,6 +72,13 @@ export function disable(element) {
   element.classList.add(ElementAction.Disable)
 }
 
+/*
+ * Generate a random number between two values
+ */
+export function randomBetween(min, max) {
+  return Math.random() * (max - min) + min;
+}
+
 // FIXME: Parsing depends on the agent (browser)
 function extractPrefix() {
   const stackTrace = Error().stack

--- a/app/views/lessons/_form.html.erb
+++ b/app/views/lessons/_form.html.erb
@@ -1,32 +1,44 @@
-<%= form_with(model: lesson, class: "lesson-form") do |form| %>
-  <% if lesson.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(lesson.errors.count, "error") %> prohibited this lesson from being saved:</h2>
+<%= form_with(
+  model: lesson,
+  class: "lesson-form",
+  data: {
+    controller: "lesson-form",
+    action: [
+      "player:videoLoadFailed@window->lesson-form#videoLoadFailed",
+      "player:videoLoaded@window->lesson-form#videoLoaded"
+    ].join(" ")
+  }) do |form| %>
+  <div style="color: red" data-lesson-form-target="errorContainer" class="<%= "hidden" if !lesson.errors.any? %>">
+      <h2>Errors prohibited this lesson from being saved:</h2>
 
-      <ul>
-        <% lesson.errors.each do |error| %>
-          <li><%= error.full_message %></li>
-        <% end %>
-      </ul>
-    </div>
-  <% end %>
+    <ul data-lesson-form-target="errorList">
+      <% lesson.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
 
   <%= form.label :name %>
-  <%= form.text_field :name, class: "large", required: true %>
+  <%= form.text_field :name, class: "large", required: true, data: { "lesson-form-target" => "field" } %>
 
   <%= form.label :video_url %>
   <%= form.text_field :video_url,
-    data: { action: "input->player#load", "player-target" =>  "source" },
+    data: { action: "input->lesson-form#load", "lesson-form-target" =>  "url" },
     class: "large",
     required: true %>
 
   <%= form.label :instrument_id, Instrument.model_name.human %>
-  <%= form.select(:instrument_id, Instrument.all.collect { |i| [i.name, i.id] }, {}, class: "small") %>
+  <%= form.select(
+    :instrument_id,
+    Instrument.all.collect { |i| [i.name, i.id] }, {},
+    class: "small",
+    data: { "lesson-form-target" => "field" }
+  ) %>
 
   <%= form.hidden_field :duration_in_seconds, data: { "player-target" => "duration" } %>
 
   <div class="form-footer">
-    <%= form.submit %>
+    <%= form.submit nil, data: { "lesson-form-target" => "field" } %>
     <%= link_to t(:cancel), lessons_path(lesson) %>
   </div>
 <% end %>

--- a/app/views/lessons/new.html.erb
+++ b/app/views/lessons/new.html.erb
@@ -1,7 +1,7 @@
 <h1>New lesson</h1>
 
 <%= turbo_frame_tag @lesson do %>
-  <div data-controller="player">
+  <div data-controller="player" data-action="lesson-form:videoUrlChanged@window->player#load">
     <div id="player" class="hidden"></div>
     <%= render "form", lesson: @lesson %>
   </div>

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -37,6 +37,7 @@
 
   <div class="video-player player"
        data-controller="player"
+       data-player-edit-value="true"
        data-action="range:connect@window->player#triggerEdition range:update@window->player#updatePoints section:connect@window->player#playFromTo section:disconnect@window->player#reset"
        data-player-video-id-value="<%= video_id(@lesson) %>">
     <div id="player"></div>

--- a/cypress/e2e/lesson.cy.js
+++ b/cypress/e2e/lesson.cy.js
@@ -1,0 +1,73 @@
+describe("Lesson", () => {
+  describe("New", () => {
+    beforeEach(() => {
+      cy.appFactories([["create", "user"]])
+      cy.forceLogin()
+      cy.findByText("New Lesson").click()
+    })
+
+    context("when the video succeeds to load", () => {
+      beforeEach(() => {
+        cy.findByLabelText("Video link")
+          .invoke("val", "https://some.com")
+          .trigger("input")
+        cy.findByLabelText("Name").should("not.have.class", "disabled")
+        cy.findByLabelText("Instrument").should("not.have.class", "disabled")
+        cy.findByText("Create Lesson").should("not.have.class", "disabled")
+      })
+
+      it("doesn't disable fields nor button", () => {
+        cy.findByText("This video is restricted from being embedded").should('not.exist')
+      })
+
+      context("and the a new url is used that fails to load", () => {
+        it("disables the rest of the fields and the the submit button and shows the error message", () => {
+          cy.get("#player").then(([player]) => {
+            player.dataset.error = "load"
+            cy.findByLabelText("Video link")
+              .invoke("val", "https://some.com")
+              .trigger("input")
+            cy.findByLabelText("Name").should("have.class", "disabled")
+            cy.findByLabelText("Instrument").should("have.class", "disabled")
+            cy.findByText("Create Lesson").should("have.class", "disabled")
+            cy.findByText("This video is restricted from being embedded")
+          })
+        })
+      })
+    })
+
+    context("when the video fails to load", () => {
+      beforeEach(() => {
+        cy.get("#player").then(([player]) => {
+          player.dataset.error = "load"
+          cy.findByLabelText("Video link")
+            .invoke("val", "https://some.com")
+            .trigger("input")
+          cy.findByLabelText("Name").should("have.class", "disabled")
+          cy.findByLabelText("Instrument").should("have.class", "disabled")
+          cy.findByText("Create Lesson").should("have.class", "disabled")
+        })
+      })
+
+      it("disables the rest of the fields and the submit button and shows the error message", () => {
+          cy.findByText("This video is restricted from being embedded")
+      })
+
+      context("and a new url is used that succeeds to load", () => {
+        it("enables the rest of the fields and the submit button and hides the error message", () => {
+          cy.get("#player").then(([player]) => {
+            delete player.dataset.error
+            console.log("The dataset", player.dataset)
+            cy.findByLabelText("Video link")
+              .invoke("val", "https://some-other.com")
+              .trigger("input")
+            cy.findByLabelText("Name").should("not.have.class", "disabled")
+            cy.findByLabelText("Instrument").should("not.have.class", "disabled")
+            cy.findByText("Create Lesson").should("not.have.class", "disabled")
+            cy.findByText("This video is restricted from being embedded").should('not.exist')
+          })
+        })
+      })
+    })
+  })
+})

--- a/cypress/e2e/zoom.cy.js
+++ b/cypress/e2e/zoom.cy.js
@@ -17,7 +17,8 @@ describe("Zoom", () => {
     beforeEach(() => {
       cy.appFactories([["create", "section"]]).then(([s]) => {
         cy.forceLogin({ redirect_to: `/lessons/${s.lesson_id}` })
-        cy.get('.fa-pencil-square-o').click()
+        cy.reload()
+        cy.get('.fa-pencil-square-o').click({force: true})
         cy.get("#section_start_time")
           .invoke('val', 10)
           .trigger('input', {force: true})


### PR DESCRIPTION
Closes #61 

On Lesson creation, disable the form if the video fails to load and show an informative error message.