### PR TITLE
[#80] Fix manual play restriction key

### DIFF
--- a/app/javascript/controllers/player/youtube_player.js
+++ b/app/javascript/controllers/player/youtube_player.js
@@ -192,6 +192,10 @@ export default class extends Player {
    * Format a YouTube url (probably from the URL in the browser) to create a url
    * to use to load a video in the player
    *
+   * As per the docs it requires "A fully qualified YouTube player URL in the format
+   * http://www.youtube.com/v/VIDEO_ID?version=3". We skip the last part until
+   * it is actually required.
+   *
    * @param {string} url The url to format
    * @return {string} The formatted url
    */
@@ -201,8 +205,21 @@ export default class extends Player {
     return `${baseUrl}${parsedUrl.pathname}`
   }
 
+  /**
+   * The key to store to indicate the restriction for the video and the user.
+   * It's formed from the videoId and the user id concatenated to ensure this
+   * check works only for this particular video and this particular user.
+   *
+   * Since the URL is taken from the youtube player we adhere to its format:
+   *
+   * https://www.youtube.com/watch?t=303&v=bcKgaIQj-uE
+   *
+   * @return {string} An unique identifier for a video and a user
+   */
   #manualPlayKey() {
-    return `${this.#player.getVideoUrl()}_${this.#userId}`
+    const videoId = new URL(this.#player.getVideoUrl()).searchParams.get("v")
+
+    return `${videoId}_${this.#userId}`
   }
 
   #hasPlayedManually() {

--- a/test/javascript/controllers/player/youtube_player_test.js
+++ b/test/javascript/controllers/player/youtube_player_test.js
@@ -2,7 +2,6 @@
 import YoutubePlayer from "../../../../app/javascript/controllers/player/youtube_player"
 import { PlayerRestriction } from "../../../../app/javascript/controllers/player/player"
 
-
 jest.useFakeTimers()
 
 describe("YoutubePlayer", () => {
@@ -15,11 +14,11 @@ describe("YoutubePlayer", () => {
         playVideo: jest.fn(),
         pauseVideo: jest.fn(),
         stopVideo: jest.fn(),
-        getVideoUrl: () => "https://youtube.com/something" ,
-        seekTo: jest.fn()
+        getVideoUrl: () => "https://youtube.com/?v=wwwww12",
+        seekTo: jest.fn(),
       })),
     }
-    threeHoursAgo = Date.now() - (3 * 3600 * 1000)
+    threeHoursAgo = Date.now() - 3 * 3600 * 1000
   })
 
   describe("canPlay", () => {
@@ -27,10 +26,10 @@ describe("YoutubePlayer", () => {
       it("plays normaly and resolves", async () => {
         const ytPlayer = new YoutubePlayer({
           containerOffsetHeight: 200,
-          userId: 1
+          userId: 1,
         })
 
-        localStorage.setItem("https://youtube.com/something_1", threeHoursAgo + 3600)
+        localStorage.setItem("wwwww12_1", threeHoursAgo + 3600)
 
         await expect(ytPlayer.canPlay()).resolves.toBe(undefined)
       })
@@ -40,17 +39,19 @@ describe("YoutubePlayer", () => {
       it("plays normaly and resolves", async () => {
         const ytPlayer = new YoutubePlayer({
           containerOffsetHeight: 200,
-          userId: 1
+          userId: 1,
         })
 
-        localStorage.setItem("https://youtube.com/something_1", threeHoursAgo - 3600)
+        localStorage.setItem("wwwww12_1", threeHoursAgo - 3600)
 
-        await expect(ytPlayer.canPlay()).rejects.toMatch(JSON.stringify({
-          restriction: PlayerRestriction.UserActionRequired,
-          message: "You must play manually to make it count towards the video creator's view count. <a href=\"\">Learn more</a>",
-        }))
+        await expect(ytPlayer.canPlay()).rejects.toMatch(
+          JSON.stringify({
+            restriction: PlayerRestriction.UserActionRequired,
+            message:
+              'You must play manually to make it count towards the video creator\'s view count. <a href="">Learn more</a>',
+          }),
+        )
       })
     })
-
   })
 })


### PR DESCRIPTION
Closes #80 

The URL format taken from the video player has a `v` query param containing the video ID. We parse the URL and take that param to continue concatenating it with the user ID and form the identification key.