### PR TITLE
[#58] Improve flash notices

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -16,4 +16,5 @@
  *= require_tree ./form
  *= require lesson
  *= require section
+ *= require flash
  */

--- a/app/assets/stylesheets/flash.css
+++ b/app/assets/stylesheets/flash.css
@@ -1,0 +1,27 @@
+.flash {
+    background: repeating-linear-gradient(
+      -45deg,
+      #8cbeb2 0px,
+      #8cbeb2 20px,
+      #cccccc 20px,
+      #cccccc 40px,
+      #d90368 40px,
+      #d90368 60px
+    );
+
+    margin-top: 20px;
+    border-radius: 4px;
+
+    .message {
+      color: var(--primary);
+      text-shadow:
+        1px 1px 0 var(--accent),
+        -1px -1px 0 var(--accent),
+        1px -1px 0 var(--accent),
+        -1px 1px 0 var(--accent),
+        2px 2px 1px var(--accent);
+      padding: 8px 12px;
+      background: rgba(255, 255, 255, 0.10);
+      font-weight: 500;
+    }
+  }

--- a/app/assets/stylesheets/layouts/main.css
+++ b/app/assets/stylesheets/layouts/main.css
@@ -30,7 +30,7 @@ body {
   /* prettier-ignore */
     grid-template-columns: 20% minmax(0, 1fr) 20%;
   /* prettier-ignore */
-  grid-template-rows: 60px; minmax(0, 1fr) 50px;
+  grid-template-rows: 60px minmax(0, 1fr) 50px;
   grid-template-areas:
       "lheader header rheader"
       ". main ."

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -22,7 +22,8 @@ class SectionsController < ApplicationController
 
     respond_to do |format|
       if @section.save
-        format.html { redirect_to lesson_url(@lesson), notice: "Section was successfully created." }
+        flash.now[:notice] = "Section was successfully created."
+        format.html { redirect_to lesson_url(@lesson)}
       else
         format.html { render :new, status: :unprocessable_entity }
       end
@@ -40,7 +41,8 @@ class SectionsController < ApplicationController
 
     respond_to do |format|
       if @section.update(updated_params)
-        format.html { redirect_to lesson_url(@lesson), notice: "Section was successfully updated." }
+        flash.now[:notice] = "Section was successfully updated."
+        format.html { redirect_to lesson_url(@lesson) }
       else
         format.html { render :edit, status: :unprocessable_entity }
       end
@@ -51,7 +53,8 @@ class SectionsController < ApplicationController
     @section.destroy
 
     respond_to do |format|
-      format.html { redirect_to lesson_url(@lesson), notice: "Section was successfully destroyed." }
+      flash.now[:notice] = "Section was successfully destroyed."
+      format.html { redirect_to lesson_url(@lesson) }
       format.turbo_stream
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def render_turbo_stream_flash_messages
+    turbo_stream.prepend "flash", partial: "layouts/flash"
+  end
 end

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,0 +1,11 @@
+<% flash.each do |flash_type, message| %>
+  <div
+    class="flash"
+    data-controller="removals"
+    data-action="animationend->removals#remove"
+  >
+    <div class="message">
+      <%= message %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,9 @@
     </header>
     <div class="rheader"></div>
     <main>
+      <div id="flash" class="flash">
+        <%= render "layouts/flash" %>
+      </div>
       <%= yield %>
     </main>
     <footer>

--- a/app/views/lessons/create.turbo_stream.erb
+++ b/app/views/lessons/create.turbo_stream.erb
@@ -2,3 +2,4 @@
 <%= turbo_stream.prepend "lessons" do %>
   <%= render @lesson %>
 <% end %>
+<%= render_turbo_stream_flash_messages %>

--- a/app/views/lessons/index.html.erb
+++ b/app/views/lessons/index.html.erb
@@ -1,5 +1,3 @@
-<p style="color: green"><%= notice %></p>
-
 <div class="lessons">
   <div class="header">
     <div class="title">

--- a/app/views/sections/index.html.erb
+++ b/app/views/sections/index.html.erb
@@ -1,5 +1,3 @@
-<p style="color: green"><%= notice %></p>
-
 <h1>Sections</h1>
 
 <div id="sections">


### PR DESCRIPTION
Closes #58 

Improve the flash notices shown in the application.

- Add actual styles
- Change the flashes to use turbo with a helper
- Use `flash.now` to make `Section`'s notices non-persistent across page reloads