### PR TITLE
[#62] Disable session controls until video is loaded

### DIFF
--- a/app/javascript/controllers/player/dummy_player.js
+++ b/app/javascript/controllers/player/dummy_player.js
@@ -51,10 +51,13 @@ export default class extends Player {
   }
 
   play(from) {
-    this.#currentTime = from
-    this.pause()
-    this.#intervalId = setInterval(() => {
-      this.#currentTime += 1
+    setTimeout(() => {
+      this.#onPlaying()
+      this.#currentTime = from
+      this.pause()
+      this.#intervalId = setInterval(() => {
+        this.#currentTime += 1
+      }, 1000)
     }, 1000)
   }
 

--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -133,7 +133,7 @@ export default class extends Controller {
 
         // Enable the New Section button
         const newSectionButton = document.querySelector("#new-section")
-        enable(newSectionButton)
+        if (newSectionButton) enable(newSectionButton)
       })
       .catch((error) => {
         console.error("Player initialization failed", error)

--- a/app/javascript/controllers/range_controller.js
+++ b/app/javascript/controllers/range_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { debounce, debug } from "controllers/util"
+import { debounce, debug, enable } from "controllers/util"
 import { ZoomType } from "controllers/zoom/zoom"
 
 export default class extends Controller {
@@ -11,6 +11,7 @@ export default class extends Controller {
   }
 
   #activeZoom
+  #hasPlayed
   #duration
 
   connect() {
@@ -150,6 +151,21 @@ export default class extends Controller {
     }
 
     this.dispatch("submitForm")
+  }
+
+  videoLoaded() {
+    if (this.#hasPlayed) return
+
+    // We use the disabled attribute here in adition to the helper functions
+    // because the CSS property pointer-events:none isn't working for the range
+    // inputs despite being active
+    this.minTarget.disabled = false
+    this.maxTarget.disabled = false
+
+    enable(this.minTarget)
+    enable(this.maxTarget)
+
+    this.#hasPlayed = true
   }
 
   #setSliderStyles(min, max) {

--- a/app/views/sections/_range.html.erb
+++ b/app/views/sections/_range.html.erb
@@ -6,6 +6,7 @@
       "player:resetRange@window->range#resetRange",
       "section-form:convertFields@window->range#convertFields",
       "zoom:zoomUpdated@window->range#updateZoomLevel",
+      "player:videoLoaded@window->range#videoLoaded"
     ].join(" "),
     "range-player-outlet" => ".player",
     "range-zoom-outlet" => ".zoom",
@@ -18,17 +19,19 @@
    <div class="range-input">
      <%= form.range_field :start_time,
        value: unless section.start_time_second.nil? then section.start_time.to_i.to_f else 0.0 end,
-       class: "min",
+       class: "min disabled",
        min: 0.0,
        max: lesson.duration_in_seconds,
        step: 0.01,
+       disabled: true,
        data: { action: "input->range#update", "range-target" => "min" } %>
      <%= form.range_field :end_time,
        value: unless section.end_time_second.nil? then section.end_time.to_i.to_f else lesson.duration_in_seconds.to_i.to_f end,
-       class: "max",
+       class: "max disabled",
        min: 0.04,
        max: lesson.duration_in_seconds,
        step: 0.01,
+       disabled: true,
        data: { action: "input->range#update", "range-target" => "max" } %>
    </div>
 <% end %>

--- a/cypress/e2e/section.cy.js
+++ b/cypress/e2e/section.cy.js
@@ -1,9 +1,52 @@
 describe("Section", () => {
   it("Loads the section", () => {
     cy.appFactories([["create", "section"]]).then(([section]) => {
-      cy.forceLogin({ redirect_to: "/lessons"})
+      cy.forceLogin({ redirect_to: "/lessons" })
       cy.get(".video-card > .title").click()
-      cy.findByText(section.name).should('exist')
+      cy.findByText(section.name).should("exist")
+    })
+  })
+
+  describe("On create", () => {
+    it("enables the range inputs when the video starts playing", () => {
+      cy.appFactories([["create", "lesson"]]).then(([lesson]) => {
+        cy.forceLogin({ redirect_to: `/lessons/${lesson.id}` })
+        cy.findByText("New Section").click()
+        cy.get("#section_start_time")
+          .should("have.class", "disabled")
+          .should("be.disabled")
+        cy.get("#section_end_time")
+          .should("have.class", "disabled")
+          .should("be.disabled")
+        cy.get("#section_start_time")
+          .should("not.have.class", "disabled")
+          .should("not.be.disabled")
+        cy.get("#section_end_time")
+          .should("not.have.class", "disabled")
+          .should("not.be.disabled")
+      })
+    })
+  })
+
+  describe("On edit", () => {
+    it("enables the range inputs when the video starts playing", () => {
+      cy.appFactories([["create", "section"]]).then(([section]) => {
+        cy.forceLogin({ redirect_to: `/lessons/${section.lesson_id}` })
+        cy.reload()
+        cy.get(".fa-pencil-square-o").click({ force: true })
+        cy.get("#section_start_time")
+          .should("have.class", "disabled")
+          .should("be.disabled")
+        cy.get("#section_end_time")
+          .should("have.class", "disabled")
+          .should("be.disabled")
+        cy.get("#section_start_time")
+          .should("not.have.class", "disabled")
+          .should("not.be.disabled")
+        cy.get("#section_end_time")
+          .should("not.have.class", "disabled")
+          .should("not.be.disabled")
+      })
     })
   })
 })

--- a/test/system/sections_test.rb
+++ b/test/system/sections_test.rb
@@ -17,6 +17,8 @@ class SectionsTest < ApplicationSystemTestCase
     click_on "New Section"
 
     fill_in "Name", with: "Part 4"
+    page.execute_script("document.querySelector('#section_start_time').disabled = false")
+    page.execute_script("document.querySelector('#section_end_time').disabled = false")
     page.execute_script("document.querySelector('#section_start_time').value = 123.2")
     page.execute_script("document.querySelector('#section_end_time').value = 323.2")
     find(".switch").click


### PR DESCRIPTION
Closes #62 

Wait for the first playback before enabling the range inputs used in the point selectors on both `Section` creation and edition.