### PR TITLE
Fix section form styles

### DIFF
--- a/app/assets/stylesheets/section.css
+++ b/app/assets/stylesheets/section.css
@@ -4,8 +4,11 @@
   margin-bottom: 10px;
   display: flex;
   flex-flow: column nowrap;
-  align-items: start;
 
+  .action {
+    align-self: start;
+  }
+  
   form {
     display: flex;
     flex-flow: row wrap;

--- a/app/views/lessons/show.html.erb
+++ b/app/views/lessons/show.html.erb
@@ -45,7 +45,9 @@
   </div>
   
   <%= turbo_frame_tag "sections", class: "sections" do %>
-    <%= button_to "#{t("actions.new")} #{Section.model_name.human}", new_lesson_section_path(@lesson), id: "new-section", method: :get, class: "button link disabled" %>
+    <div class="action">
+      <%= button_to "#{t("actions.new")} #{Section.model_name.human}", new_lesson_section_path(@lesson), id: "new-section", method: :get, class: "button link disabled" %>
+    </div>
     <div class="sections-selector">
       <%= render partial: "sections/section_item", collection: @lesson.sections, as: :section, locals: { lesson: @lesson }%>
     </div>


### PR DESCRIPTION
Remove the start alignment of the whole flex container for `Section` content in `Lesson#show` and add it to the "New Section" button only. We wrap the button because it gets replaced with a form by turbo and it inherits the `section.form` styles, which is not the intended behavior.