### PR TITLE
[#81] Disable range inputs around Loop clear

### DIFF
--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -235,7 +235,9 @@ export default class extends Controller {
     this.editState = rest
 
     // Disable the fields here and enable them after the clear
+    this.dispatch("loopClearStarted")
     this.loopManager.clear()
+    this.dispatch("loopClearFinished")
 
     switch (state.zoom) {
       case ZoomType.In:

--- a/app/javascript/controllers/range_controller.js
+++ b/app/javascript/controllers/range_controller.js
@@ -1,5 +1,5 @@
 import { Controller } from "@hotwired/stimulus"
-import { debounce, debug, enable } from "controllers/util"
+import { debounce, debug, enable, disable } from "controllers/util"
 import { ZoomType } from "controllers/zoom/zoom"
 
 export default class extends Controller {
@@ -156,14 +156,7 @@ export default class extends Controller {
   videoLoaded() {
     if (this.#hasPlayed) return
 
-    // We use the disabled attribute here in adition to the helper functions
-    // because the CSS property pointer-events:none isn't working for the range
-    // inputs despite being active
-    this.minTarget.disabled = false
-    this.maxTarget.disabled = false
-
-    enable(this.minTarget)
-    enable(this.maxTarget)
+    this.enableInputs()
 
     this.#hasPlayed = true
   }
@@ -191,5 +184,27 @@ export default class extends Controller {
 
   #isZoomed() {
     return this.#activeZoom.isZoomed
+  }
+
+  enableInputs() {
+    // We use the disabled attribute here in adition to the helper functions
+    // because the CSS property pointer-events:none isn't working for the range
+    // inputs despite being active
+    this.minTarget.disabled = false
+    this.maxTarget.disabled = false
+
+    enable(this.minTarget)
+    enable(this.maxTarget)
+  }
+
+  disableInputs() {
+    // We use the disabled attribute here in adition to the helper functions
+    // because the CSS property pointer-events:none isn't working for the range
+    // inputs despite being active
+    this.minTarget.disabled = true
+    this.maxTarget.disabled = true
+
+    disable(this.minTarget)
+    disable(this.maxTarget)
   }
 }

--- a/app/views/sections/_range.html.erb
+++ b/app/views/sections/_range.html.erb
@@ -6,7 +6,9 @@
       "player:resetRange@window->range#resetRange",
       "section-form:convertFields@window->range#convertFields",
       "zoom:zoomUpdated@window->range#updateZoomLevel",
-      "player:videoLoaded@window->range#videoLoaded"
+      "player:videoLoaded@window->range#videoLoaded",
+      "player:loopClearStarted@window->range#disableInputs",
+      "player:loopClearFinished@window->range#enableInputs"
     ].join(" "),
     "range-player-outlet" => ".player",
     "range-zoom-outlet" => ".zoom",


### PR DESCRIPTION
Closes #81 

Before and after the `LoopManager` performs a clear action we enable and disable the range inputs respectively.