### PR TITLE
[#103] Fix playback after manual play

### DIFF
--- a/app/javascript/controllers/player/dummy_player.js
+++ b/app/javascript/controllers/player/dummy_player.js
@@ -65,7 +65,7 @@ export default class extends Player {
     clearInterval(this.#intervalId)
   }
 
-  canPlay(_from) {
+  canPlay() {
     debug("Can the dummy play?")
 
     const playerElement = document.querySelector("#player")

--- a/app/javascript/controllers/player/loop_manager.js
+++ b/app/javascript/controllers/player/loop_manager.js
@@ -23,8 +23,8 @@ export default class LoopManager {
     this.#player = player
   }
 
-  #canLoop(from) {
-    return this.#player.canPlay(from)
+  #canLoop() {
+    return this.#player.canPlay()
   }
 
   /**
@@ -40,7 +40,7 @@ export default class LoopManager {
    * loop
    */
   async loop(from, to, max = null) {
-    await this.#canLoop(from)
+    await this.#canLoop()
 
     // We need to stop any previous loop before we start a new one
     this.clear()

--- a/app/javascript/controllers/player/player.js
+++ b/app/javascript/controllers/player/player.js
@@ -65,7 +65,7 @@ export default class Player {
    * Can play
    *
    */
-  async canPlay(from) {
+  async canPlay() {
     throw new Error("Abstract method canPlay must be implemented")
   }
 

--- a/app/javascript/controllers/player/state.js
+++ b/app/javascript/controllers/player/state.js
@@ -139,12 +139,21 @@ export class UserActionRequiredState extends PlayerState {
   }
 
   onPlaying() {
+    // Stop manual play so we can turn playback into a loop
     this.context.player.pause()
-    this.context.loop(
-      this.context.pendingLoop.start,
-      this.context.pendingLoop.end,
-    )
+
+    // Restore the state before restriction
+    this.context.state = this.context.pendingState || this.context.playingState
+
+    // Clear pending loop and state
+    // eslint-disable-next-line no-warning-comments
+    // TODO: This should be unified early perhaps
+    this.context.pendingState = null
+
+    // We loop in the state we were before we were interrupted by some invariant
+    const { start, end } = this.context.pendingLoop
     this.context.pendingLoop = null
-    this.context.state = this.context.playingState
+
+    this.context.loop(start, end)
   }
 }

--- a/app/javascript/controllers/player/youtube_player.js
+++ b/app/javascript/controllers/player/youtube_player.js
@@ -70,7 +70,9 @@ export default class extends Player {
               if (!this.#hasPlayedManually()) {
                 debug("setting the played manually value")
                 localStorage.setItem(this.#manualPlayKey(), Date.now())
+                params.onRestrictionLifted()
               }
+
               params.onPlaying()
               break
           }
@@ -100,17 +102,13 @@ export default class extends Player {
     return this.#player.getCurrentTime()
   }
 
-  canPlay(from) {
+  canPlay() {
     debug("can it play", this.#hasPlayedManually())
     return new Promise((resolve, reject) => {
       if (this.#hasPlayedManually()) {
         debug("Has played manually")
         resolve()
       } else {
-        debug("hasn't played manually, rejecting")
-        // We seek to the right value so that manual playback for the user still
-        // starts at the desired point
-        this.#player.seekTo(from, true)
         reject(
           JSON.stringify({
             restriction: PlayerRestriction.UserActionRequired,

--- a/app/javascript/controllers/player_controller.js
+++ b/app/javascript/controllers/player_controller.js
@@ -41,14 +41,17 @@ export default class extends Controller {
 
   /**
    * Pending loop definition
-   * 
+   *
    * @typedef {Object} PendingLoop
    * @property {!number} start
    * @property {!number} end
    * /
-  
+
   /** @property {PendingLoop} */
   pendingLoop
+
+  /** @property {PlayerState} */
+  pendingState
 
   /** @property {LoopManager} */
   loopManager
@@ -116,6 +119,8 @@ export default class extends Controller {
         debug("onSectionCancel is being fired and resetting everything", event)
         this.reset()
         this.dispatch("zoomCancelled")
+        this.pendingState = null
+        this.pendingLoop = null
       }
     }
   }
@@ -196,6 +201,7 @@ export default class extends Controller {
   loop(start, end) {
     return this.state.loop(start, end).catch((error) => {
       this.pendingLoop = { start, end }
+      this.pendingState = this.state
       this.state = this.userActionRequiredState
       this.#handlePlayerRestrictions(error)
     })
@@ -354,7 +360,8 @@ export default class extends Controller {
         if (this.hasDurationTarget) {
           this.durationTarget.value = parseInt(this.player.duration, 10)
         }
-
+      },
+      onRestrictionLifted: () => {
         this.state.onPlaying()
       },
       onLoadError: () => {


### PR DESCRIPTION
Closes #103 

The seekTo method of the YouTube player will start playing automatically when in certain states like CUED. Since we are already keeping track of the pending loop and our logic follows hijacking the manually-triggered playback to start a loop, we just stop seeking and let the player stay as is. 

It's simpler for the user because the player doesn't change any state and it keeps showing the big red PLAY button in the center of the player but it will be completely communicated to the user that we're still expecting their action once the #77 tooltip is put in place (even if they clicked away the alert without reading).